### PR TITLE
Workaround for simonmar/async#14

### DIFF
--- a/test/main.hs
+++ b/test/main.hs
@@ -9,6 +9,7 @@ import Data.IORef
 import Data.Typeable
 import Control.Monad.IO.Class
 import Control.Concurrent (throwTo, threadDelay, forkIO)
+import Control.Concurrent.MVar (newEmptyMVar, takeMVar)
 import Control.Exception.Enclosed
 
 {-# ANN main ("HLint: ignore Redundant do"::String) #-}
@@ -44,6 +45,12 @@ main = hspec $ do
                     | Just DummyException <- fromException e -> return ()
                     | otherwise -> error "Expected a DummyException"
                 Right () -> error "Expected an exception" :: IO ()
+
+    it "MVar deadlocks simonmar/async#14" $ do
+        res <- tryAny $ newEmptyMVar >>= takeMVar
+        case res of
+            Left _ -> return ()
+            Right () -> error "Expected Left value"
 
 data DummyException = DummyException
     deriving (Show, Typeable)


### PR DESCRIPTION
Pinging @simonmar. Thank you for your response in the tickets. However,
the StablePtr technique simply caused this test suite to hang
indefinitely. Instead, I'm trying to catch the BlockedIndefinitelyOnSTM
exception sent by the RTS, which seems to work reliably.

Pinging @sol. This change needs to be included in hspec as well. Without
a patch, for example, the enclosed-exceptions test suite still fails,
since hspec ends up letting the test die due to the
BlockedIndefinitelyOnSTM exception being sent to it as well. I can send
a pull request after this is reviewed/accepted into enclosed-exceptions.
